### PR TITLE
Add ai-plat-service module with OpenAI chat completion controller.

### DIFF
--- a/ai-plat-service/pom.xml
+++ b/ai-plat-service/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.binary2all.ai.plat</groupId>
+        <artifactId>smart-assistants-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath> <!-- Points to the parent POM -->
+    </parent>
+
+    <artifactId>ai-plat-service</artifactId>
+    <name>AI Platform Service Module</name>
+    <description>Sub-module for AI Platform specific services</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ai-plat-service/src/main/java/org/binary2all/ai/plat/service/AiPlatServiceApplication.java
+++ b/ai-plat-service/src/main/java/org/binary2all/ai/plat/service/AiPlatServiceApplication.java
@@ -1,0 +1,13 @@
+package org.binary2all.ai.plat.service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AiPlatServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AiPlatServiceApplication.class, args);
+    }
+
+}

--- a/ai-plat-service/src/main/java/org/binary2all/ai/plat/service/controller/ChatController.java
+++ b/ai-plat-service/src/main/java/org/binary2all/ai/plat/service/controller/ChatController.java
@@ -1,0 +1,70 @@
+package org.binary2all.ai.plat.service.controller;
+
+import org.springframework.ai.openai.OpenAiChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.model.ChatResponse;
+
+@RestController
+@RequestMapping("/api/v1/chat")
+public class ChatController {
+
+    private final OpenAiChatClient chatClient;
+
+    @Autowired
+    public ChatController(OpenAiChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    // Define a simple DTO for the request
+    public static class ChatRequest {
+        private String message;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    // Define a simple DTO for the response
+    public static class ChatCompletionResponse {
+        private String reply;
+
+        public ChatCompletionResponse(String reply) {
+            this.reply = reply;
+        }
+
+        public String getReply() {
+            return reply;
+        }
+
+        public void setReply(String reply) {
+            this.reply = reply;
+        }
+    }
+
+    @PostMapping("/completions")
+    public ChatCompletionResponse getChatCompletion(@RequestBody ChatRequest chatRequest) {
+        if (chatRequest == null || chatRequest.getMessage() == null || chatRequest.getMessage().isEmpty()) {
+            // Consider throwing an appropriate HTTP error like 400 Bad Request
+            return new ChatCompletionResponse("Error: Message cannot be empty.");
+        }
+        
+        Prompt prompt = new Prompt(chatRequest.getMessage());
+        ChatResponse aiResponse = chatClient.call(prompt);
+        
+        if (aiResponse != null && aiResponse.getResult() != null) {
+            return new ChatCompletionResponse(aiResponse.getResult().getOutput().getContent());
+        } else {
+            // Handle cases where the response or its content might be null
+            return new ChatCompletionResponse("Error: No response from AI model.");
+        }
+    }
+}

--- a/ai-plat-service/src/main/resources/application.properties
+++ b/ai-plat-service/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+# OpenAI Configuration
+spring.ai.openai.api-key=YOUR_API_KEY_HERE
+# Please replace YOUR_API_KEY_HERE with your actual OpenAI API key.
+
+# Optional: Define a default model (if not specified, Spring AI will use a default like gpt-3.5-turbo)
+# spring.ai.openai.chat.options.model=gpt-4

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
     <modules>
         <module>ai-service</module>
+        <module>ai-plat-service</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This commit introduces the new 'ai-plat-service' module:
- Includes dependencies for Spring Web and Spring AI OpenAI.
- Added to the parent POM.
- Basic Spring Boot application class `AiPlatServiceApplication.java`.
- Implemented `ChatController` with a POST endpoint `/api/v1/chat/completions` to interact with OpenAI's chat completion.
- Uses `OpenAiChatClient` and simple DTOs for request/response.
- Added `application.properties` with a placeholder for the OpenAI API key.